### PR TITLE
Fix styling of keyboard keys on FAQ page

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -130,15 +130,15 @@ that can be toggled to get back to standard emacs.
 <h3 id="sec-2">How do you select text when using ergoemacs-mode and ergoemacs-arrow keys</h3>
 <div class="outline-text-3" id="text-2">
 
-<p>You can hold the left @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@,
+<p>You can hold the left <kbd class="dark">Alt</kbd>,
 then right hand press space to mark, then right hand using any of
 QWERTY 
-@@html:&lt;kbd class="dark"&gt;@@i@@html:&lt;/kbd&gt;@@ 
-@@html:&lt;kbd class="dark"&gt;@@j@@html:&lt;/kbd&gt;@@ 
-@@html:&lt;kbd class="dark"&gt;@@k@@html:&lt;/kbd&gt;@@ 
-@@html:&lt;kbd class="dark"&gt;@@l@@html:&lt;/kbd&gt;@@ to move by char, line, or 
-@@html:&lt;kbd class="dark"&gt;@@u@@html:&lt;/kbd&gt;@@ 
-@@html:&lt;kbd class="dark"&gt;@@o@@html:&lt;/kbd&gt;@@  to move
+<kbd class="dark">i</kbd> 
+<kbd class="dark">j</kbd> 
+<kbd class="dark">k</kbd> 
+<kbd class="dark">l</kbd> to move by char, line, or 
+<kbd class="dark">u</kbd> 
+<kbd class="dark">o</kbd>  to move
 by word. ⇧ Shift+U and ⇧ Shift+O to move by paragraph/block.
 </p>
 <p>


### PR DESCRIPTION
Fixed some accidentally escaped HTML in FAQ page for keyboard keys. 