### PR TITLE
PCKeyboardHack for Mac has been replaced by Karabiner

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -199,11 +199,11 @@ F13 or above, and tell emacs that F13 is actually the menu key.  This
 is done by:
 </p>
 <ol>
-<li>Downloading and installing <a href="https://pqrs.org/macosx/keyremap4macbook/pckeyboardhack.html">PCKeyboardHack</a>
+<li>Downloading and installing <a href="https://pqrs.org/osx/karabiner/index.html">Karabiner</a>
 </li>
-<li>Going to the system prefences and PCKeyboardHack
+<li>Going to the Simple Modifications tab in Karabiner
 </li>
-<li>Change the caps lock mapping to F13
+<li>Adding a mapping from caps lock to F13
 </li>
 <li>Adding the translation to emacs startup script (like ~/.emacs or
    ~/.emacs.d/init.el) as follows:


### PR DESCRIPTION
PCKeyboardHack is no longer available and has been replaced by Karabiner. 
I tested out Karabiner and it does the trick.