### PR TITLE
Fix keyboard key stylings

### DIFF
--- a/banish-key-chords.html
+++ b/banish-key-chords.html
@@ -142,21 +142,21 @@ I came up with the Ctrl+c and Ctrl+x replacements:
 </p>
 <ul>
 <li>Ctrl-x commands can be accessed by QWERTY 
-  @@html:&lt;kbd class="dark"&gt;@@Menu@@html:&lt;/kbd&gt;@@  @@html:&lt;kbd class="dark"&gt;@@d@@html:&lt;/kbd&gt;@@
+  <kbd class="dark">Menu</kbd>  <kbd class="dark">d</kbd>
 <ul>
 <li>This is <b>not</b> the same as the traditional Ctrl+x. Heres how its
     different:
 <ul>
-<li>By default all @@html:&lt;kbd class="dark"&gt;@@Ctrl@@html:&lt;/kbd&gt;@@ commands are translated to @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@ commands.
+<li>By default all <kbd class="dark">Ctrl</kbd> commands are translated to <kbd class="dark">Alt</kbd> commands.
 <ul>
-<li>Ctrl+x Ctrl+b could be accessed by @@html:&lt;kbd class="dark"&gt;@@Menu@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@d@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@+@@html:&lt;kbd class="dark"&gt;@@b@@html:&lt;/kbd&gt;@@ (list-buffers)
+<li>Ctrl+x Ctrl+b could be accessed by <kbd class="dark">Menu</kbd> <kbd class="dark">d</kbd> <kbd class="dark">Alt</kbd>+<kbd class="dark">b</kbd> (list-buffers)
 </li>
-<li>C-x b could be accessed by @@html:&lt;kbd class="dark"&gt;@@Menu@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@d@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@b@@html:&lt;/kbd&gt;@@ (switch-to-buffer)
+<li>C-x b could be accessed by <kbd class="dark">Menu</kbd> <kbd class="dark">d</kbd> <kbd class="dark">b</kbd> (switch-to-buffer)
 </li>
 </ul>
 
 </li>
-<li>Pressing @@html:&lt;kbd class="dark"&gt;@@Menu@@html:&lt;/kbd&gt;@@ will
+<li>Pressing <kbd class="dark">Menu</kbd> will
       change the type of key translation used.  The default for Ctrl+x is
       translate/swap the Alt and Ctl keys.  Pressing Menu again will:
 <ul>
@@ -192,7 +192,7 @@ For your information, an "unchorded" filter/translation would translate:
 
 </li>
 <li>C-c commands can be accessed by QWERTY 
-  @@html:&lt;kbd class="dark"&gt;@@Menu@@html:&lt;/kbd&gt;@@  @@html:&lt;kbd class="dark"&gt;@@f@@html:&lt;/kbd&gt;@@
+  <kbd class="dark">Menu</kbd>  <kbd class="dark">f</kbd>
 <ul>
 <li>This is <b>not</b> the same as the traditional Ctrl+c. Heres how its
     different:
@@ -203,7 +203,7 @@ For your information, an "unchorded" filter/translation would translate:
       less strain on your hand to have these key combinations to be
       unchorded by default.
 </li>
-<li>@@html:&lt;kbd class="dark"&gt;@@Ctrl@@html:&lt;/kbd&gt;@@ commands are translated to @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@ commands.
+<li><kbd class="dark">Ctrl</kbd> commands are translated to <kbd class="dark">Alt</kbd> commands.
 </li>
 </ul>
 

--- a/design-basis.html
+++ b/design-basis.html
@@ -137,10 +137,10 @@ are listed roughly in order of priority:
 </li>
 <li>Right hand's keys are considered better than left hand's keys. (because most people are right handed)
 </li>
-<li>@@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@ is considered better
-   than @@html:&lt;kbd class="dark"&gt;@@Ctrl@@html:&lt;/kbd&gt;@@. (@@html:&lt;kbd
-   class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@ 
-   is a natural thumb curl, @@html:&lt;kbd class="dark"&gt;@@Ctrl@@html:&lt;/kbd&gt;@@ is
+<li><kbd class="dark">Alt</kbd> is considered better
+   than <kbd class="dark">Ctrl</kbd>. (<kbd
+   class="dark">Alt</kbd> 
+   is a natural thumb curl, <kbd class="dark">Ctrl</kbd> is
    stretched pinky. Thumb is most powerful finger, pinkie the weakest)
 </li>
 <li>In general, cursor moving commands are placed all for the right
@@ -149,10 +149,10 @@ are listed roughly in order of priority:
 </li>
 <li>Similar commands should be grouped together to avoid
    scattering. For example, cursor moving by single char is together
-   (@@html:&lt;kbd class="dark"&gt;@@I@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@J@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@K@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@L@@html:&lt;/kbd&gt;@@). Undo, Cut, Copy, Paste are together (@@html:&lt;kbd class="dark"&gt;@@Z@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@X@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@C@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@V@@html:&lt;/kbd&gt;@@). Delete
-   char/word left/right are together (@@html:&lt;kbd class="dark"&gt;@@E@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@R@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@D@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@F@@html:&lt;/kbd&gt;@@).
+   (<kbd class="dark">I</kbd> <kbd class="dark">J</kbd> <kbd class="dark">K</kbd> <kbd class="dark">L</kbd>). Undo, Cut, Copy, Paste are together (<kbd class="dark">Z</kbd> <kbd class="dark">X</kbd> <kbd class="dark">C</kbd> <kbd class="dark">V</kbd>). Delete
+   char/word left/right are together (<kbd class="dark">E</kbd> <kbd class="dark">R</kbd> <kbd class="dark">D</kbd> <kbd class="dark">F</kbd>).
 </li>
-<li>Commands with logical reversal or extension are done with @@html:&lt;kbd class="dark"&gt;@@⇧ Shift@@html:&lt;/kbd&gt;@@
+<li>Commands with logical reversal or extension are done with <kbd class="dark">⇧ Shift</kbd>
    key, after other priorities are considered. Examples: Undo/Redo,
    move cursor to previous/next pane, find replace by string/regex,
    isearch forward/backward, move cursor by beginning/ending of
@@ -169,11 +169,11 @@ grouping and positioning. For example, cursor movings are all right
 hand, text changing are all left hand, moving or deleting to the
 left/right have keys that are place left and right together, and
 similar for up/down (by screen or to beginning/end of file). Undo,
-Cut, Copy, Paste are the familiar row @@html:&lt;kbd class="dark"&gt;@@Z@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@X@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@C@@html:&lt;/kbd&gt;@@ @@html:&lt;kbd class="dark"&gt;@@V@@html:&lt;/kbd&gt;@@.
+Cut, Copy, Paste are the familiar row <kbd class="dark">Z</kbd> <kbd class="dark">X</kbd> <kbd class="dark">C</kbd> <kbd class="dark">V</kbd>.
 </p>
 <p>
-In this design, only the @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@+@@html:&lt;kbd class="dark"&gt;@@‹key›@@html:&lt;/kbd&gt;@@ space is used. Some @@html:&lt;kbd class="dark"&gt;@@Alt@@html:&lt;/kbd&gt;@@+@@html:&lt;kbd class="dark"&gt;@@⇧ Shift@@html:&lt;/kbd&gt;@@
-is used too. @@html:&lt;kbd class="dark"&gt;@@Ctrl@@html:&lt;/kbd&gt;@@+@@html:&lt;kbd class="dark"&gt;@@‹key›@@html:&lt;/kbd&gt;@@ space is not used except 7 standard
+In this design, only the <kbd class="dark">Alt</kbd>+<kbd class="dark">‹key›</kbd> space is used. Some <kbd class="dark">Alt</kbd>+<kbd class="dark">⇧ Shift</kbd>
+is used too. <kbd class="dark">Ctrl</kbd>+<kbd class="dark">‹key›</kbd> space is not used except 7 standard
 keybindings (Open, Close, Save, Save As, Print, Select All). The
 operation and consistency of emacs is not affected.
 </p>


### PR DESCRIPTION
Keyboard key styling repaired on Design Basis and Banish Key Chords pages.

Not sure what you used to author these pages to introduce these escape characters.  I won't be at all offended if you reject my pull requests and make corrections at source, but the offending pages are currently really hard on the eye and not readable as they stand now - which is kind of a shame for a project relating to ergonomics.   Content is great BTW, thanks.