### PR TITLE
Change Emacs Modernization Redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@ A minor-mode that aims to:
 <a href="http://ergoemacs.org/emacs/emacs_keys_index.html"><i>icon-keyboard-wireless icon-white</i> Keyboard Articles</a>
 </p>
 <p>
-<a href="http://ergoemacs.org/emacs/emacs_modernization.html">Emacs Modernization</a>
+<a href="http://xahlee.info/emacs/emacs/emacs_modernization.html">Emacs Modernization</a>
 </p>
 <p>
 <a href="http://ergoemacs.org/emacs/blog.html"><i>icon-blog icon-white</i> Emacs Blog</a>


### PR DESCRIPTION
Seemed as though it would be more useful to directly link to xahlee's website, rather than a page that says this page was moved to a new URL.